### PR TITLE
fix bug in case the QP does not converge

### DIFF
--- a/src/dynamically_consistent_end_effector_trajectory.cpp
+++ b/src/dynamically_consistent_end_effector_trajectory.cpp
@@ -566,7 +566,7 @@ int DynamicallyConsistentEndEffectorTrajectory::get_forces(
     {
         if (!qp_solver_.solve(Q_, q_, A_eq_, B_eq_, A_ineq_, B_ineq_))
         {
-            forces = forces.tail(forces.size() - 3);
+            forces.head(forces.size() - 3) = forces.tail(forces.size() - 3);
         }
         else
         {


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

I think the idea here was to do a MPC style sllide on the solution if the QP is not solved.
Hence we take the previous solution and we use it as the current solution, no?
The code tried to do that but actually seg-faulted inside this if.
So this modification.

## How I Tested

[//]: # "Explain how you tested your changes"

Compiled and run on my machine.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
